### PR TITLE
Use <Leader> for for plugin mapping

### DIFF
--- a/plugin/wap_it.vim
+++ b/plugin/wap_it.vim
@@ -26,5 +26,5 @@ function! WapDescribe()
   endif
 endfunction
 
-:nmap ,wi :call WapIt()<CR>
-:nmap ,wd :call WapDescribe()<CR>
+:nmap <Leader>wi :call WapIt()<CR>
+:nmap <Leader>wd :call WapDescribe()<CR>


### PR DESCRIPTION
This uses `<Leader>` instead of `,` for the the various wap functions, so everyone can use their leader key of choice. Also,  I :heart: this plugin.